### PR TITLE
fix: mutual tls failures caused by shadowed var

### DIFF
--- a/src/database-backup-restore/system_tests/postgresql_mutual_tls/postgresql_mutual_tls_test.go
+++ b/src/database-backup-restore/system_tests/postgresql_mutual_tls/postgresql_mutual_tls_test.go
@@ -23,8 +23,6 @@ var _ = Describe("postgres with mutual tls", func() {
 
 		postgresClientCertPath string
 		postgresClientKeyPath  string
-
-		brJob JobInstance
 	)
 
 	BeforeEach(func() {


### PR DESCRIPTION
I believe I just found the issue:
**`brJob` variable was being shadowed in mutualTLS test.**

It matches the evidence from previous attempts at fixing this that GHActions started failing after this change:
https://github.com/cloudfoundry/backup-and-restore-sdk-release/commit/36c02f2da94031eda44a6b179d118f782acf43fc#diff-5d849bbfd0385ad6fa69c0b511d89ffa3fdd81386421cb6fd8ffd33f4451ed89

I believe, what made this issue so hard to spot was:

**The PR is huge**

This made it easy to assume that some dependency just broke something down the stack.

**The PR name suggests that "it's just a version bump" (`chore: bump to Ginkgo V2`)**

However, the reality is very different. The PR also refactors several areas of the code. One of those introduced the bug by accidentally shadowing the brJob variable.

**Concourse pipelines didn't break because of this PR**

This made it easy to assume the issue was caused by some incompatibility by the usage of bosh-in-docker in these tests. 
However, the reality is that **Concourse tests are not running mutual_tls scenario at all**, otherwise they would have been red all this time.

**We trust existing Concourse pipelines (maybe too much)**

Me and the rest of the team assumed very early that something must be wrong with:
- Bosh-in-docker
- GH Actions
- docker-compose
- etc.

And that everything must be ok since Concourse pipelines were green.
It is a reasonable assumption, given the complex setup of these tests and the whole BOSH-in-Docker idea.
However, as demonstrated by this fix, this assumption was probably biased and didn't consider the possibility of existing Concourse pipelines being incomplete or buggy.

------------------------

I noticed this by pure chance after I decided to pay more attention to the following error in the logs:
https://github.com/cloudfoundry/backup-and-restore-sdk-release/actions/runs/8626416900/job/23644612742#step:5:1651

Then I went to compare postgres_tls against postgres_mutual_tls line by line.
That's what helped me spot the bug.

See how brJob is set on BeforeSuite:
- https://github.com/cloudfoundry/backup-and-restore-sdk-release/blob/main/src/database-backup-restore/system_tests/postgresql_mutual_tls/postgresql_mutual_tls_suite_test.go#L40
- https://github.com/cloudfoundry/backup-and-restore-sdk-release/blob/734c7f8a47b5528995962d29ab068df13eb23c52/src/database-backup-restore/system_tests/postgresql_tls/postgresql_tls_suite_test.go#L38

See how brJob is redeclared on Describe in mutual_tls:
- https://github.com/cloudfoundry/backup-and-restore-sdk-release/blob/734c7f8a47b5528995962d29ab068df13eb23c52/src/database-backup-restore/system_tests/postgresql_mutual_tls/postgresql_mutual_tls_test.go#L27
- https://github.com/cloudfoundry/backup-and-restore-sdk-release/blob/3d18b5c1e29868d390f5c86d7aff11064cfef768/src/database-backup-restore/system_tests/postgresql_tls/postgresql_tls_test.go#L15-L22

----------------------

I'm writing such an extensive PR description with the hope of reminding us of the importance of:
- Small, focused, single-purpose PRs
- Contrasting assumptions and staying alert towards technical biases
- Working as a team, collaborating and joining our different strengths (More eyes on these tests would have mean more chances to spot the issue)
